### PR TITLE
binding: fix NegateTerm to consume Term before Expr.

### DIFF
--- a/binding/parse_test.go
+++ b/binding/parse_test.go
@@ -8,7 +8,7 @@ import (
 
 var _ = Suite(&ParseTest{})
 
-type ParseTest struct {}
+type ParseTest struct{}
 
 func (t *ParseTest) expectParsingError(c *C, data string) {
 	_, err := ParseString(data)
@@ -29,7 +29,7 @@ func (t *ParseTest) TestParseTerm(c *C) {
 }
 
 func (t *ParseTest) TestParseNegativeTerm(c *C) {
-	data := t.parse(c , "! as")
+	data := t.parse(c, "! as")
 	param, ok := data.(*definition.Negate)
 	c.Assert(ok, Equals, true)
 	c.Assert(param.Negated.(*definition.Parameter).Identification, Equals, "as")
@@ -104,7 +104,7 @@ func (t *ParseTest) TestParseAndOr(c *C) {
 }
 
 func (t *ParseTest) TestParseBrackets(c *C) {
-	data := t.parse(c , "(left1 | left2) & (right1 | right2)")
+	data := t.parse(c, "(left1 | left2) & (right1 | right2)")
 	outerAnd, ok := data.(*definition.And)
 	c.Assert(ok, Equals, true)
 	_, ok = outerAnd.Left.(*definition.Or)
@@ -114,7 +114,7 @@ func (t *ParseTest) TestParseBrackets(c *C) {
 }
 
 func (t *ParseTest) TestParseOneBracket(c *C) {
-	data := t.parse(c , "(left1 | left2) & right1 | right2")
+	data := t.parse(c, "(left1 | left2) & right1 | right2")
 	outerAnd, ok := data.(*definition.Or)
 	c.Assert(ok, Equals, true)
 	_, ok = outerAnd.Right.(*definition.Parameter)
@@ -128,9 +128,27 @@ func (t *ParseTest) TestParseOneBracket(c *C) {
 }
 
 func (t *ParseTest) TestParseNegation(c *C) {
+	data := t.parse(c, "!item1 & (item2 | item3)")
+	outerAnd, ok := data.(*definition.And)
+	c.Assert(ok, Equals, true)
+	_, ok = outerAnd.Left.(*definition.Negate)
+	c.Assert(ok, Equals, true)
+	_, ok = outerAnd.Right.(*definition.Or)
+	c.Assert(ok, Equals, true)
+}
+
+func (t *ParseTest) TestParseNegationAnd(c *C) {
 	data := t.parse(c, "!(item1 & item2)")
 	outerNegation, ok := data.(*definition.Negate)
 	c.Assert(ok, Equals, true)
 	_, ok = outerNegation.Negated.(*definition.And)
+	c.Assert(ok, Equals, true)
+}
+
+func (t *ParseTest) TestParseNegationOr(c *C) {
+	data := t.parse(c, "!(item1 | item2)")
+	outerNegation, ok := data.(*definition.Negate)
+	c.Assert(ok, Equals, true)
+	_, ok = outerNegation.Negated.(*definition.Or)
 	c.Assert(ok, Equals, true)
 }

--- a/binding/queryBinding.peg
+++ b/binding/queryBinding.peg
@@ -35,7 +35,7 @@ And <- left:(NegateTerm / Term / Bracket) _ '&' _ right:(And / Bracket / NegateT
   return and, nil
 }
 
-NegateTerm <- _ '!' _ first:Expr _ {
+NegateTerm <- _ '!' _ first:(Term / Expr) _ {
   return definition.NewNegate(first), nil
 }
 


### PR DESCRIPTION
Thanks for sharing this project :+1: , I ran into an issue parsing the below example and this seems to fix it, although I am new to PEG and there may be a better way to do this.

---

A binding like "!item1 & (item2 | item3)" would end up parsing as
!(item1 & (item2 | item3)) with the change in 2f640df to allow for nested
definitions of negations. With this change the more specific Term is checked
first so the above is correctly parsed while still allowing for negating nested
definitions.

Prior to this change `!item1 & (item2 | item3)` parsed as:
```go
(*definition.Negate)(0xc420124e70)({
 Param: (definition.Param) {
 },
 Negated: (*definition.And)(0xc420166400)({
  LeftRight: (definition.LeftRight) {
   Param: (definition.Param) {
   },
   Left: (*definition.Parameter)(0xc4201291c0)({
    Param: (definition.Param) {
    },
    Identification: (string) (len=5) "item1",
    Name: (string) "",
    Filter: (*definition.Filter)(<nil>),
    Value: (interface {}) <nil>
   }),
   Right: (*definition.Or)(0xc420166340)({
    LeftRight: (definition.LeftRight) {
     Param: (definition.Param) {
     },
     Left: (*definition.Parameter)(0xc420129940)({
      Param: (definition.Param) {
      },
      Identification: (string) (len=5) "item2",
      Name: (string) "",
      Filter: (*definition.Filter)(<nil>),
      Value: (interface {}) <nil>
     }),
     Right: (*definition.Parameter)(0xc420129c80)({
      Param: (definition.Param) {
      },
      Identification: (string) (len=5) "item3",
      Name: (string) "",
      Filter: (*definition.Filter)(<nil>),
      Value: (interface {}) <nil>
     })
    }
   })
  }
 })
 })
```

now parses as:
```go
(*definition.And)(0xc420117300)({
 LeftRight: (definition.LeftRight) {
  Param: (definition.Param) {
  },
  Left: (*definition.Negate)(0xc420124a90)({
   Param: (definition.Param) {
   },
   Negated: (*definition.Parameter)(0xc42010b7c0)({
    Param: (definition.Param) {
    },
    Identification: (string) (len=5) "item1",
    Name: (string) "",
    Filter: (*definition.Filter)(<nil>),
    Value: (interface {}) <nil>
   })
  }),
  Right: (*definition.Or)(0xc420117260)({
   LeftRight: (definition.LeftRight) {
    Param: (definition.Param) {
    },
    Left: (*definition.Parameter)(0xc42010bbc0)({
     Param: (definition.Param) {
     },
     Identification: (string) (len=5) "item2",
     Name: (string) "",
     Filter: (*definition.Filter)(<nil>),
     Value: (interface {}) <nil>
    }),
    Right: (*definition.Parameter)(0xc42010bdc0)({
     Param: (definition.Param) {
     },
     Identification: (string) (len=5) "item3",
     Name: (string) "",
     Filter: (*definition.Filter)(<nil>),
     Value: (interface {}) <nil>
    })
   }
  })
 }
})
```